### PR TITLE
Changed order of docker-compose blocks to fix YAML parse error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,29 +42,24 @@ services:
     environment:
       - NGINX_DOCKER_GEN_CONTAINER=nginx-gen
 
-# Create data docker volumes
-volumes:
-  shiny-apps:
-  r-packages:
-
 # Spin up a Shiny docker
-shiny:
-    restart: always
-    image: rocker/shiny
-    container_name: shiny
-    expose:
-      - "3838"
-    environment:
-      - VIRTUAL_HOST=shiny.mydomain.com
-      - VIRTUAL_NETWORK=nginx-proxy
-      - VIRTUAL_PORT=80
-      - LETSENCRYPT_HOST=shiny.mydomain.com
-      - LETSENCRYPT_EMAIL=me@myemail.com
-    volumes:
-      - shiny-apps:/srv/shiny-server/
-      - ./volumes/shiny/logs:/var/log/
-      - r-packages:/usr/local/lib/R/site-library
-      
+  shiny:
+      restart: always
+      image: rocker/shiny
+      container_name: shiny
+      expose:
+        - "3838"
+      environment:
+        - VIRTUAL_HOST=shiny.mydomain.com
+        - VIRTUAL_NETWORK=nginx-proxy
+        - VIRTUAL_PORT=80
+        - LETSENCRYPT_HOST=shiny.mydomain.com
+        - LETSENCRYPT_EMAIL=me@myemail.com
+      volumes:
+        - shiny-apps:/srv/shiny-server/
+        - ./volumes/shiny/logs:/var/log/
+        - r-packages:/usr/local/lib/R/site-library
+
 # Spin up Rstudio docker
 
 ## Use this version to add several users
@@ -106,5 +101,8 @@ shiny:
       - shiny-apps:/home/YOUR_USER/apps
       - r-packages:/usr/local/lib/R/site-library
 
-
+# Create data docker volumes
+volumes:
+  shiny-apps:
+  r-packages:
 


### PR DESCRIPTION
The tidyverse and shiny services should be declared before the volumes.